### PR TITLE
fix: check for forbidden URLs when creating split view

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -135,6 +135,35 @@ let rightUrl = null;
 
 let tab = null;
 
+const FORBIDDEN_HOSTNAMES = [
+  "accounts-static.cdn.mozilla.net",
+  "accounts.firefox.com",
+  "addons.cdn.mozilla.net",
+  "addons.mozilla.org",
+  "api.accounts.firefox.com",
+  "content.cdn.mozilla.net",
+  "discovery.addons.mozilla.org",
+  "install.mozilla.org",
+  "oauth.accounts.firefox.com",
+  "profile.accounts.firefox.com",
+  "support.mozilla.org",
+  "sync.services.mozilla.com"
+];
+
+function isForbiddenUrl(url) {
+  if (!url) return true;
+  if (url.startsWith("moz-extension:")) return true;
+  if (url.startsWith("about:")) return true;
+  if (url.startsWith("file:")) return true;
+  try {
+    const urlObj = new URL(url);
+    if (FORBIDDEN_HOSTNAMES.includes(urlObj.hostname)) return true;
+  } catch (_) {
+    return true;
+  }
+  return false;
+}
+
 async function fetchTabs(sender, sendResponse) {
   try {
     const tabs = await browser.tabs.query({ currentWindow: true });
@@ -302,7 +331,7 @@ const handleInitializeExtension = async (side) => {
       currentWindow: true
     });
     const activeTab = activeTabs[0];
-    const currentUrl = activeTab.url;
+    const currentUrl = isForbiddenUrl(activeTab.url) ? null : activeTab.url;
 
     // Creates a new tab containing the split view
     tab = await browser.tabs.create({


### PR DESCRIPTION
## Summary
- Added `isForbiddenUrl()` check in `handleInitializeExtension` so that opening the split view from a forbidden page (about:, moz-extension:, file:, or Mozilla internal domains) opens the searchbar instead of trying to load the forbidden URL into an iframe
- Reuses the same forbidden hostname list from `urls.ts` to keep behavior consistent

## Test plan
- [ ] Open split view from `about:addons` → should show searchbar, not crash
- [ ] Open split view from `addons.mozilla.org` → should show searchbar
- [ ] Open split view from a normal page → should load normally

Fixes #19

> Automated fix by buildingvibes